### PR TITLE
chore: use stylistic plugin for deprecated stylistic rules

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import unicorn from 'eslint-plugin-unicorn';
 import unusedImports from 'eslint-plugin-unused-imports';
 import { configs as wdioPlugin } from 'eslint-plugin-wdio';
 import type { TSESLint } from '@typescript-eslint/utils';
+import stylistic from '@stylistic/eslint-plugin'
 
 /**
  * ESLint configuration for OutSystem projects.
@@ -22,9 +23,11 @@ const baseConfigs: tseslint.ConfigWithExtends[] = [
         extends: [
             wdioPlugin['flat/recommended']
         ],
+
         plugins: {
             unicorn,
             'unused-imports': unusedImports,
+            '@stylistic': stylistic,
         },
 
         languageOptions: {
@@ -34,52 +37,47 @@ const baseConfigs: tseslint.ConfigWithExtends[] = [
         },
 
         rules: {
-            quotes: ['error', 'single', {
+            /**
+             * Stylistic rules
+             */
+            '@stylistic/quotes': ['error', 'single', {
                 avoidEscape: true,
             }],
+            '@stylistic/semi': ['error', 'never'],
+            '@stylistic/indent': [2, 4],
+            '@stylistic/no-multiple-empty-lines': [2, {
+                max: 1,
+                maxEOF: 1,
+            }],
+            '@stylistic/array-bracket-spacing': ['error', 'never'],
+            '@stylistic/brace-style': ['error', '1tbs', {
+                allowSingleLine: true,
+            }],
+            '@stylistic/comma-spacing': ['error', {
+                before: false,
+                after: true,
+            }],
+            '@stylistic/no-tabs': 'error',
+            '@stylistic/no-trailing-spaces': ['error', {
+                skipBlankLines: false,
+                ignoreComments: false,
+            }],
+            '@stylistic/object-curly-spacing': ['error', 'always'],
+            '@stylistic/keyword-spacing': ['error'],
+            '@stylistic/linebreak-style': ['error', 'unix'],
 
             camelcase: ['error', {
                 properties: 'never',
             }],
-
-            semi: ['error', 'never'],
-            indent: [2, 4],
             eqeqeq: ['error', 'always'],
             'prefer-const': 'error',
-
-            'no-multiple-empty-lines': [2, {
-                max: 1,
-                maxEOF: 1,
-            }],
-
-            'array-bracket-spacing': ['error', 'never'],
-
-            'brace-style': ['error', '1tbs', {
-                allowSingleLine: true,
-            }],
-
-            'comma-spacing': ['error', {
-                before: false,
-                after: true,
-            }],
-
             'no-lonely-if': 'error',
             'dot-notation': 'error',
             'no-else-return': 'error',
-            'no-tabs': 'error',
-
-            'no-trailing-spaces': ['error', {
-                skipBlankLines: false,
-                ignoreComments: false,
-            }],
-
             'no-var': 'error',
             'unicode-bom': ['error', 'never'],
             curly: ['error', 'all'],
-            'object-curly-spacing': ['error', 'always'],
-            'keyword-spacing': ['error'],
             'require-atomic-updates': 0,
-            'linebreak-style': ['error', 'unix'],
             'unicorn/prefer-node-protocol': ['error'],
             'no-restricted-syntax': ['error', 'IfStatement > ExpressionStatement > AssignmentExpression'],
             'unicorn/prefer-ternary': 'error',

--- a/package.json
+++ b/package.json
@@ -28,13 +28,14 @@
     "url": "https://github.com/webdriverio/eslint/issues"
   },
   "dependencies": {
-    "globals": "^16.0.0",
     "@eslint/js": "^9.15.0",
-    "typescript-eslint": "^8.18.1",
+    "@stylistic/eslint-plugin": "^4.2.0",
+    "@typescript-eslint/utils": "^8.14.0",
     "eslint-plugin-unicorn": "^58.0.0",
     "eslint-plugin-unused-imports": "^4.1.4",
     "eslint-plugin-wdio": "^9.2.11",
-    "@typescript-eslint/utils": "^8.14.0"
+    "globals": "^16.0.0",
+    "typescript-eslint": "^8.18.1"
   },
   "devDependencies": {
     "release-it": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.15.0
         version: 9.23.0
+      '@stylistic/eslint-plugin':
+        specifier: ^4.2.0
+        version: 4.2.0(eslint@9.15.0)(typescript@5.8.2)
       '@typescript-eslint/utils':
         specifier: ^8.14.0
         version: 8.27.0(eslint@9.15.0)(typescript@5.8.2)
@@ -278,6 +281,12 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@stylistic/eslint-plugin@4.2.0':
+    resolution: {integrity: sha512-8hXezgz7jexGHdo5WN6JBEIPHCSFyyU4vgbxevu4YLVS5vl+sxqAAGyXSzfNDyR6xMNSH5H1x67nsXcYMOHtZA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=9.0.0'
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -1227,6 +1236,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -1858,6 +1871,18 @@ snapshots:
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@stylistic/eslint-plugin@4.2.0(eslint@9.15.0)(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/utils': 8.27.0(eslint@9.15.0)(typescript@5.8.2)
+      eslint: 9.15.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      estraverse: 5.3.0
+      picomatch: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -2811,6 +2836,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
Stylistic rules used in this config have been deprecated ([see deprecation note](https://eslint.org/blog/2023/10/deprecating-formatting-rules/))

This PR aims to change those rules to use the corresponding [`@stylistic/eslint-plugin`](https://eslint.style/) ones.