### PR TITLE
fix: change switch statement indent to 0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -44,8 +44,8 @@ const baseConfigs: tseslint.ConfigWithExtends[] = [
                 avoidEscape: true,
             }],
             '@stylistic/semi': ['error', 'never'],
-            '@stylistic/indent': [2, 4],
-            '@stylistic/no-multiple-empty-lines': [2, {
+            '@stylistic/indent': ['error', 4, { 'SwitchCase': 0 }],
+            '@stylistic/no-multiple-empty-lines': ['error', {
                 max: 1,
                 maxEOF: 1,
             }],


### PR DESCRIPTION
While trying to bump on `webdriverio` repo, I noticed a lot of changes related to the indent of switch case.
It is supposed to be the default (0), but it doesn't work for some reason, I will investigate this a bit later.

This doesn't hurt to be more explicit anyway.